### PR TITLE
Adding Beep Boop multi-team support and fixing a few error cases

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ if (token) {
   require('beepboop-botkit').start(controller, { debug: true })
 }
 
-controller.hears('.*', ['direct_mention'], function (bot, message) {
+controller.hears('.*', ['direct_mention', 'direct_message'], function (bot, message) {
 
   // The address submitted by the user.
   var address = message.text;

--- a/index.js
+++ b/index.js
@@ -38,6 +38,11 @@ controller.hears('.*', ['direct_mention'], function (bot, message) {
         bot.reply(message, 'Sorry, I was unable to look up the trashday for that address.');
       }
       else {
+        var feature = JSON.parse(data).features[0]
+        if (!feature ) {
+          return bot.reply(message, 'Sorry, I was unable to look up the trashday for that address.');
+        }
+
         var day = JSON.parse(data).features[0].attributes.Day;
         bot.reply(message, 'Your trash day is on ' + config.titleCase(day));
       }
@@ -54,7 +59,12 @@ function geoCodeAddress(address, callback) {
 
 // Look up the user's trash day.
 function lookUpTrashDay(geodata, callback) {
-  var location = JSON.parse(geodata).results[0].geometry.location;
+  var result = JSON.parse(geodata).results[0]
+  if (!result) {
+    return callback(new Error('no results returned'))
+  }
+
+  var location = result.geometry.location;
   url = config.lahub_url_template.replace('%geometry%', location.lng + ',' + location.lat);
   request(url, function(error, response, body) {
     callback(error, body);

--- a/index.js
+++ b/index.js
@@ -3,17 +3,21 @@ var request = require('request');
 var async = require('async');
 var config = require('./config').config
 
-if(!process.env.SLACK_TOKEN) {
-  console.error('SLACK_TOKEN is required!');
-  process.exit(1);
-}
+var token = process.env.SLACK_TOKEN
 
 var controller = Botkit.slackbot()
-var bot = controller.spawn({ token: process.env.SLACK_TOKEN }).startRTM(function (err, bot, payload) {
-  if(err) {
-    throw new Error('Could not connect to Slack');
-  }
-});
+
+if (token) {
+  console.log("Starting in single-team mode")
+  controller.spawn({ token: token }).startRTM(function(err,bot,payload) {
+    if (err) {
+      throw new Error('Could not connect to Slack')
+    }
+  })
+} else {
+  console.log("Starting in Beep Boop multi-team mode")
+  require('beepboop-botkit').start(controller, { debug: true })
+}
 
 controller.hears('.*', ['direct_mention'], function (bot, message) {
 
@@ -25,10 +29,10 @@ controller.hears('.*', ['direct_mention'], function (bot, message) {
    * 2. Lookup trash day using coordinates.
    * 3. Render response to user.
    */
-  async.waterfall([ 
+  async.waterfall([
       async.apply(geoCodeAddress, address),
       lookUpTrashDay
-    ], 
+    ],
     function(error, data) {
       if(error) {
         bot.reply(message, 'Sorry, I was unable to look up the trashday for that address.');

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "license": "MIT",
   "dependencies": {
     "async": "^1.5.2",
+    "beepboop-botkit": "^1.1.1",
     "botkit": "0.0.15",
     "request": "^2.70.0"
   }


### PR DESCRIPTION
I added the ability to run this bot as a multi-team bot on Beep Boop by wiring in the `beepboop-botkit` module.  As a multi-team bot it allows you to make it public and easy for anyone to add directly to their team via an "Add to Slack" button.  More details on what's happening with the `beepboop-botkit` module can be [found here](https://beepboophq.com/docs/article/resourcer-api), but in essence, instead of expecting a `SLACK_TOKEN` when the bot starts up, it receives messages over a socket connection to a Beep Boop service when teams add/remove the bot.  This allows your single bot process to handle many teams, and also allows Beep Boop to scale your bot to multiple processes if needed.  

I left in the ability to run in single team mode as that's sometimes useful for development, or in case others that fork this want that functionality.
- Also fixed a few error cases I found as I tried some addresses that don't return results.
- Added support for direct messages to the bot
